### PR TITLE
layout.conf: enabled thin manifests

### DIFF
--- a/metadata/layout.conf
+++ b/metadata/layout.conf
@@ -1,1 +1,2 @@
 masters = gentoo
+thin-manifests = true


### PR DESCRIPTION
to avoid keeping useless clutter in the repository